### PR TITLE
Adds support for brackets, UNC paths. Cleans up gs2patcher.bat

### DIFF
--- a/gs2patcher.bat
+++ b/gs2patcher.bat
@@ -1,22 +1,19 @@
 @ECHO OFF
-SET APPDIR=%CD%
-SET HOLD=%PATH%
-SET PATH=%PATH%;%APPDIR%\lua
+pushd %~dp0
 
-IF NOT EXIST "%APPDIR%\patch" (
+IF NOT EXIST "patch\" (
   ECHO Patch directory does not exist.  Do not move or delete package files.
-  ECHO Expected to find \patch in %APPDIR%
+  ECHO Expected to find \patch in "%CD%"
+  pause
   GOTO :quit
 )
 
-IF EXIST "%APPDIR%\patch\temp" (
-  RMDIR /S /Q "%APPDIR%\patch\temp"
-)
-MKDIR "%APPDIR%\patch\temp"
+RMDIR /S /Q "patch\temp" 2>NUL
+MKDIR "patch\temp"
 
-lua-interface patchdlg.lua -e main_patch()
+lua\lua-interface patchdlg.lua -e main_patch()
 
-RMDIR /S /Q "%APPDIR%\patch\temp"
+RMDIR /S /Q "patch\temp"
 
 :quit
-SET PATH=%HOLD%
+popd


### PR DESCRIPTION
Closes pyriell/gs2-bugfixes#8.
Adds support for () brackets in working directory.
Adds support for UNC paths.
Adds support for incorrect working directories.

Cleans up gs2patcher.bat in general, removing unnecessary variables, logic, and
  Env.Path manipulation, reducing the file size.
Note that this means Lua is now being launched relative to the batch file. I couldn't find
  any problems with this in testing, but I'm not so familiar with Lua, so maybe I'm being naive.